### PR TITLE
Use span attribute in colgroups; omit empty colgroups

### DIFF
--- a/src/components/analysis/parsing/abstract_lr_table_component.jsx
+++ b/src/components/analysis/parsing/abstract_lr_table_component.jsx
@@ -7,18 +7,14 @@ function isConflict(actions) {
 
 export default function({ grammar, table, includeEnd }) {
   const { productions, symbolInfo } = grammar.calculations;
+  const terminalColumnCount = symbolInfo.terminals.size + (includeEnd ? 1 : 0);
+  const nonterminalColumnCount = symbolInfo.nonterminals.size;
 
   return (
     <table className="symbols lr-table">
-      <colgroup>
-        <col />
-      </colgroup>
-      <colgroup className="t">
-        {fillArray(symbolInfo.terminals.size + (includeEnd ? 1 : 0), (index) => <col key={index} />)}
-      </colgroup>
-      <colgroup className="nt">
-        {fillArray(symbolInfo.nonterminals.size, (index) => <col key={index} />)}
-      </colgroup>
+      <colgroup span="1"></colgroup>
+      {terminalColumnCount > 0 ? <colgroup className="t" span={terminalColumnCount}></colgroup> : []}
+      {nonterminalColumnCount > 0 ? <colgroup className="nt" span={nonterminalColumnCount}></colgroup> : []}
 
       <thead>
         <tr>

--- a/src/components/analysis/parsing/ll1_table_component.jsx
+++ b/src/components/analysis/parsing/ll1_table_component.jsx
@@ -12,12 +12,8 @@ export default function({ grammar }) {
       <h2>{TITLE}</h2>
 
       <table className="symbols ll1-table">
-        <colgroup>
-          <col />
-        </colgroup>
-        <colgroup className="t">
-          {fillArray(symbolInfo.terminals.size + 1, (index) => <col key={index} />)}
-        </colgroup>
+        <colgroup span="1"></colgroup>
+        <colgroup className="t" span={symbolInfo.terminals.size + 1}></colgroup>
 
         <thead>
           <tr>


### PR DESCRIPTION
This fixes the display of LR(0) parsing tables for grammars without terminals.

Further, using the `span` attribute in templates is a bit easier to read than producing `<col>` elements.

This is related to #41 but doesn't actually address the issue.