### PR TITLE
Include end of input symbol in LR(0) tables

### DIFF
--- a/src/components/analysis/parsing/lr0_table_component.jsx
+++ b/src/components/analysis/parsing/lr0_table_component.jsx
@@ -10,7 +10,7 @@ export default function({ grammar }) {
       <AbstractLRTableComponent
         grammar={grammar}
         table={grammar.calculations.lr0Table}
-        includeEnd={false}
+        includeEnd={true}
       />
     </section>
   );

--- a/src/grammar/calculations/parsing/lr/lr0_table.js
+++ b/src/grammar/calculations/parsing/lr/lr0_table.js
@@ -1,3 +1,4 @@
+import { END } from "../../../symbols.js";
 import { addReduceAction } from "./helpers.js";
 
 export default function({ productions, lr0Automaton: automaton, symbolInfo }) {
@@ -19,7 +20,7 @@ export default function({ productions, lr0Automaton: automaton, symbolInfo }) {
 
     // add reduce actions for completed items
 
-    for (s of symbolInfo.terminalOrder) {
+    for (s of symbolInfo.terminalOrder.concat(END)) {
 
       for (j = 0; j < state.items.length; j++) {
 

--- a/test/fixtures/example_output.js
+++ b/test/fixtures/example_output.js
@@ -773,6 +773,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -795,6 +800,11 @@ export default {
           ]
         },
         "d": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -833,6 +843,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -863,6 +878,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -882,6 +902,11 @@ export default {
           ]
         },
         "d": {
+          "reduce": [
+            3
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             3
           ]
@@ -2067,6 +2092,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -2118,6 +2148,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -2140,6 +2175,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -2159,6 +2199,11 @@ export default {
           ]
         },
         "z": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -3805,6 +3850,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -3848,6 +3898,11 @@ export default {
           "reduce": [
             1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            1
+          ]
         }
       },
       {
@@ -3872,6 +3927,11 @@ export default {
           ]
         },
         "lamb": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -3908,6 +3968,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -3932,6 +3997,11 @@ export default {
           ]
         },
         "lamb": {
+          "reduce": [
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2
           ]
@@ -3978,6 +4048,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -4005,6 +4080,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -4029,6 +4109,11 @@ export default {
           ]
         },
         "lamb": {
+          "reduce": [
+            6
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             6
           ]
@@ -5676,6 +5761,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -5702,6 +5792,12 @@ export default {
             2,
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2,
+            3
+          ]
         }
       },
       {
@@ -5716,6 +5812,11 @@ export default {
           ]
         },
         "num": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -5752,6 +5853,11 @@ export default {
           "reduce": [
             1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            1
+          ]
         }
       },
       {
@@ -5772,6 +5878,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -5789,6 +5900,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -5803,6 +5919,11 @@ export default {
           ]
         },
         "num": {
+          "reduce": [
+            4
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             4
           ]
@@ -7678,6 +7799,12 @@ export default {
             3,
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3,
+            4
+          ]
         }
       },
       {
@@ -7697,6 +7824,11 @@ export default {
           ]
         },
         ")": {
+          "reduce": [
+            -1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             -1
           ]
@@ -7724,6 +7856,11 @@ export default {
           ]
         },
         ")": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -7768,6 +7905,12 @@ export default {
             3,
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3,
+            4
+          ]
         }
       },
       {
@@ -7793,6 +7936,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -7812,6 +7960,11 @@ export default {
           ]
         },
         ")": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -7852,6 +8005,12 @@ export default {
             3,
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3,
+            4
+          ]
         }
       },
       {
@@ -7876,6 +8035,11 @@ export default {
           ]
         },
         ")": {
+          "reduce": [
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2
           ]
@@ -10483,6 +10647,13 @@ export default {
             3,
             7
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            1,
+            3,
+            7
+          ]
         }
       },
       {
@@ -10512,6 +10683,11 @@ export default {
           ]
         },
         "o": {
+          "reduce": [
+            -1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             -1
           ]
@@ -10563,6 +10739,11 @@ export default {
           "reduce": [
             6
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            6
+          ]
         }
       },
       {
@@ -10595,6 +10776,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -10624,6 +10810,11 @@ export default {
           ]
         },
         "o": {
+          "reduce": [
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2
           ]
@@ -10672,6 +10863,12 @@ export default {
             3,
             7
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3,
+            7
+          ]
         }
       },
       {
@@ -10705,6 +10902,11 @@ export default {
           ]
         },
         ")": {
+          "reduce": [
+            7
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             7
           ]
@@ -10750,6 +10952,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -10784,6 +10991,11 @@ export default {
           ]
         },
         "o": {
+          "reduce": [
+            5
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             5
           ]
@@ -13023,6 +13235,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -13037,6 +13254,11 @@ export default {
           ]
         },
         "r": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -13096,6 +13318,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -13113,6 +13340,11 @@ export default {
           "reduce": [
             1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            1
+          ]
         }
       },
       {
@@ -13127,6 +13359,11 @@ export default {
           ]
         },
         "r": {
+          "reduce": [
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2
           ]
@@ -13144,6 +13381,11 @@ export default {
           ]
         },
         "r": {
+          "reduce": [
+            3
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             3
           ]
@@ -14829,6 +15071,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -14864,6 +15111,11 @@ export default {
           ]
         },
         "s": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -14913,6 +15165,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -14940,6 +15197,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -14967,6 +15229,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -14994,6 +15261,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -15018,6 +15290,11 @@ export default {
           ]
         },
         "s": {
+          "reduce": [
+            3
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             3
           ]
@@ -17005,6 +17282,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -17073,6 +17355,11 @@ export default {
           "reduce": [
             1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            1
+          ]
         }
       },
       {
@@ -17100,6 +17387,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -17124,6 +17416,11 @@ export default {
           ]
         },
         ";": {
+          "reduce": [
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2
           ]
@@ -17171,6 +17468,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -17195,6 +17497,11 @@ export default {
           ]
         },
         ";": {
+          "reduce": [
+            3
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             3
           ]
@@ -19831,6 +20138,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -19852,6 +20164,11 @@ export default {
           ]
         },
         "b": {
+          "reduce": [
+            8
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             8
           ]
@@ -19879,6 +20196,11 @@ export default {
           "reduce": [
             8
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            8
+          ]
         }
       },
       {
@@ -19888,6 +20210,11 @@ export default {
           ]
         },
         "b": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -19915,6 +20242,12 @@ export default {
             6,
             7
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            6,
+            7
+          ]
         }
       },
       {
@@ -19924,6 +20257,11 @@ export default {
           ]
         },
         "b": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -19949,6 +20287,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -19958,6 +20301,11 @@ export default {
           ]
         },
         "b": {
+          "reduce": [
+            3
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             3
           ]
@@ -19970,6 +20318,11 @@ export default {
           ]
         },
         "b": {
+          "reduce": [
+            4
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             4
           ]
@@ -19982,6 +20335,11 @@ export default {
           ]
         },
         "b": {
+          "reduce": [
+            5
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             5
           ]
@@ -22112,6 +22470,11 @@ export default {
           "reduce": [
             7
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            7
+          ]
         }
       },
       {
@@ -22126,6 +22489,11 @@ export default {
           ]
         },
         ")": {
+          "reduce": [
+            -1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             -1
           ]
@@ -22155,6 +22523,11 @@ export default {
           ]
         },
         ")": {
+          "reduce": [
+            7
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             7
           ]
@@ -22188,6 +22561,12 @@ export default {
             5,
             6
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5,
+            6
+          ]
         }
       },
       {
@@ -22202,6 +22581,11 @@ export default {
           ]
         },
         ")": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -22232,6 +22616,11 @@ export default {
           "reduce": [
             1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            1
+          ]
         }
       },
       {
@@ -22249,6 +22638,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -22263,6 +22657,11 @@ export default {
           ]
         },
         ")": {
+          "reduce": [
+            3
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             3
           ]
@@ -22280,6 +22679,11 @@ export default {
           ]
         },
         ")": {
+          "reduce": [
+            4
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             4
           ]
@@ -26479,6 +26883,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -26513,6 +26922,11 @@ export default {
           ]
         },
         "num": {
+          "reduce": [
+            -1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             -1
           ]
@@ -26560,6 +26974,11 @@ export default {
           ]
         },
         "num": {
+          "reduce": [
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2
           ]
@@ -26614,6 +27033,11 @@ export default {
           "reduce": [
             11
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            11
+          ]
         }
       },
       {
@@ -26653,6 +27077,11 @@ export default {
           ]
         },
         "num": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -26710,6 +27139,12 @@ export default {
             7,
             9
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            7,
+            9
+          ]
         }
       },
       {
@@ -26744,6 +27179,11 @@ export default {
           ]
         },
         "num": {
+          "reduce": [
+            8
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             8
           ]
@@ -26786,6 +27226,11 @@ export default {
           ]
         },
         "num": {
+          "reduce": [
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2
           ]
@@ -26840,6 +27285,11 @@ export default {
           "reduce": [
             11
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            11
+          ]
         }
       },
       {
@@ -26882,6 +27332,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -26921,6 +27376,11 @@ export default {
           ]
         },
         "num": {
+          "reduce": [
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2
           ]
@@ -26981,6 +27441,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -27018,6 +27483,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -27055,6 +27525,11 @@ export default {
           "reduce": [
             10
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            10
+          ]
         }
       },
       {
@@ -27089,6 +27564,11 @@ export default {
           ]
         },
         "num": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -27134,6 +27614,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -27176,6 +27661,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -27213,6 +27703,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -27247,6 +27742,11 @@ export default {
           ]
         },
         "num": {
+          "reduce": [
+            6
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             6
           ]
@@ -31229,6 +31729,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -31253,6 +31758,11 @@ export default {
           ]
         },
         "r": {
+          "reduce": [
+            -1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             -1
           ]
@@ -31293,6 +31803,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -31317,6 +31832,11 @@ export default {
           ]
         },
         "r": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -31355,6 +31875,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -31383,6 +31908,11 @@ export default {
           ]
         },
         "fo": {
+          "reduce": [
+            3
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             3
           ]
@@ -31415,6 +31945,11 @@ export default {
           ]
         },
         "r": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -33718,6 +34253,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -33759,6 +34299,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -33783,6 +34328,11 @@ export default {
           ]
         },
         "expr": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -33818,6 +34368,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -33846,6 +34401,11 @@ export default {
           ]
         },
         ")": {
+          "reduce": [
+            3
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             3
           ]
@@ -33882,6 +34442,11 @@ export default {
           ]
         },
         ")": {
+          "reduce": [
+            3
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             3
           ]
@@ -33925,6 +34490,11 @@ export default {
           ]
         },
         "expr": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -39322,6 +39892,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -39373,6 +39948,11 @@ export default {
           ]
         },
         "id": {
+          "reduce": [
+            16
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             16
           ]
@@ -39445,6 +40025,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -39511,6 +40096,11 @@ export default {
           ]
         },
         "*": {
+          "reduce": [
+            5
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             5
           ]
@@ -39583,6 +40173,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -39630,6 +40225,11 @@ export default {
           "reduce": [
             6
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            6
+          ]
         }
       },
       {
@@ -39677,6 +40277,11 @@ export default {
           "reduce": [
             7
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            7
+          ]
         }
       },
       {
@@ -39724,6 +40329,11 @@ export default {
           "reduce": [
             8
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            8
+          ]
         }
       },
       {
@@ -39771,6 +40381,11 @@ export default {
           "reduce": [
             9
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            9
+          ]
         }
       },
       {
@@ -39818,6 +40433,11 @@ export default {
           "reduce": [
             10
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            10
+          ]
         }
       },
       {
@@ -39865,6 +40485,11 @@ export default {
           "reduce": [
             11
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            11
+          ]
         }
       },
       {
@@ -39912,6 +40537,11 @@ export default {
           "reduce": [
             12
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            12
+          ]
         }
       },
       {
@@ -39956,6 +40586,11 @@ export default {
           ]
         },
         "*": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -40022,6 +40657,11 @@ export default {
           "reduce": [
             18
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            18
+          ]
         }
       },
       {
@@ -40069,6 +40709,11 @@ export default {
           "reduce": [
             1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            1
+          ]
         }
       },
       {
@@ -40116,6 +40761,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -40163,6 +40813,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -40210,6 +40865,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -40257,6 +40917,11 @@ export default {
           "reduce": [
             13
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            13
+          ]
         }
       },
       {
@@ -40301,6 +40966,11 @@ export default {
           ]
         },
         "*": {
+          "reduce": [
+            14
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             14
           ]
@@ -40352,6 +41022,11 @@ export default {
           ]
         },
         "id": {
+          "reduce": [
+            16
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             16
           ]
@@ -40410,6 +41085,11 @@ export default {
           "reduce": [
             18
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            18
+          ]
         }
       },
       {
@@ -40457,6 +41137,11 @@ export default {
           "reduce": [
             15
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            15
+          ]
         }
       },
       {
@@ -40501,6 +41186,11 @@ export default {
           ]
         },
         "*": {
+          "reduce": [
+            17
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             17
           ]
@@ -45830,6 +46520,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -45846,6 +46541,12 @@ export default {
           ]
         },
         "num": {
+          "reduce": [
+            0,
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0,
             2
@@ -45886,6 +46587,11 @@ export default {
           "reduce": [
             1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            1
+          ]
         }
       },
       {
@@ -45903,6 +46609,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -45917,6 +46628,11 @@ export default {
           ]
         },
         "num": {
+          "reduce": [
+            4
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             4
           ]
@@ -45934,6 +46650,11 @@ export default {
           ]
         },
         "num": {
+          "reduce": [
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2
           ]
@@ -47652,6 +48373,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -47666,6 +48392,11 @@ export default {
           ]
         },
         "id": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -47687,6 +48418,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -47701,6 +48437,11 @@ export default {
           ]
         },
         "id": {
+          "reduce": [
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2
           ]
@@ -47735,6 +48476,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -47766,6 +48512,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -47783,6 +48534,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -47797,6 +48553,11 @@ export default {
           ]
         },
         "id": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -49656,6 +50417,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -49682,6 +50448,12 @@ export default {
           ]
         },
         "w": {
+          "reduce": [
+            2,
+            3
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2,
             3
@@ -49724,6 +50496,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -49746,6 +50523,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -49763,6 +50545,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -49777,6 +50564,11 @@ export default {
           ]
         },
         "w": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -50916,6 +51708,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -50930,6 +51727,11 @@ export default {
           ]
         },
         "stmt": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -50958,6 +51760,11 @@ export default {
           "reduce": [
             1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            1
+          ]
         }
       },
       {
@@ -50977,6 +51784,11 @@ export default {
           ]
         },
         "stmt": {
+          "reduce": [
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2
           ]
@@ -52721,6 +53533,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -52748,6 +53565,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -52772,6 +53594,11 @@ export default {
           ]
         },
         "id": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -52810,6 +53637,11 @@ export default {
           ]
         },
         "id": {
+          "reduce": [
+            7
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             7
           ]
@@ -52854,6 +53686,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -52881,6 +53718,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -52908,6 +53750,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -52935,6 +53782,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -52959,6 +53811,11 @@ export default {
           ]
         },
         "id": {
+          "reduce": [
+            6
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             6
           ]
@@ -54296,6 +55153,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -54313,6 +55175,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -54327,6 +55194,11 @@ export default {
           ]
         },
         "(": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -54355,6 +55227,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -54369,6 +55246,11 @@ export default {
           ]
         },
         "(": {
+          "reduce": [
+            3
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             3
           ]
@@ -56387,6 +57269,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -56419,6 +57306,11 @@ export default {
           "reduce": [
             8
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            8
+          ]
         }
       },
       {
@@ -56443,6 +57335,11 @@ export default {
           "reduce": [
             8
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            8
+          ]
         }
       },
       {
@@ -56452,6 +57349,11 @@ export default {
           ]
         },
         "b": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -56479,6 +57381,12 @@ export default {
             6,
             7
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            6,
+            7
+          ]
         }
       },
       {
@@ -56488,6 +57396,11 @@ export default {
           ]
         },
         "b": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -56513,6 +57426,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -56522,6 +57440,11 @@ export default {
           ]
         },
         "b": {
+          "reduce": [
+            3
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             3
           ]
@@ -56534,6 +57457,11 @@ export default {
           ]
         },
         "b": {
+          "reduce": [
+            4
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             4
           ]
@@ -56546,6 +57474,11 @@ export default {
           ]
         },
         "b": {
+          "reduce": [
+            5
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             5
           ]
@@ -59244,6 +60177,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -59276,6 +60214,11 @@ export default {
           "reduce": [
             1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            1
+          ]
         }
       },
       {
@@ -59300,6 +60243,11 @@ export default {
           ]
         },
         "+": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -59342,6 +60290,11 @@ export default {
           "reduce": [
             10
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            10
+          ]
         }
       },
       {
@@ -59381,6 +60334,11 @@ export default {
           "reduce": [
             10
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            10
+          ]
         }
       },
       {
@@ -59405,6 +60363,11 @@ export default {
           ]
         },
         "+": {
+          "reduce": [
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2
           ]
@@ -59450,6 +60413,12 @@ export default {
             9,
             8
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            9,
+            8
+          ]
         }
       },
       {
@@ -59474,6 +60443,11 @@ export default {
           ]
         },
         "+": {
+          "reduce": [
+            3
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             3
           ]
@@ -59514,6 +60488,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -59541,6 +60520,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -59568,6 +60552,11 @@ export default {
           "reduce": [
             6
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            6
+          ]
         }
       },
       {
@@ -59592,6 +60581,11 @@ export default {
           ]
         },
         "+": {
+          "reduce": [
+            7
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             7
           ]
@@ -62981,6 +63975,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -63016,6 +64015,11 @@ export default {
           "reduce": [
             8
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            8
+          ]
         }
       },
       {
@@ -63035,6 +64039,11 @@ export default {
           ]
         },
         "*": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -63070,6 +64079,11 @@ export default {
           "reduce": [
             11
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            11
+          ]
         }
       },
       {
@@ -63096,6 +64110,12 @@ export default {
             6,
             7
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            6,
+            7
+          ]
         }
       },
       {
@@ -63115,6 +64135,11 @@ export default {
           ]
         },
         "*": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -63145,6 +64170,11 @@ export default {
           "reduce": [
             11
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            11
+          ]
         }
       },
       {
@@ -63172,6 +64202,11 @@ export default {
           "reduce": [
             8
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            8
+          ]
         }
       },
       {
@@ -63191,6 +64226,11 @@ export default {
           ]
         },
         "*": {
+          "reduce": [
+            4
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             4
           ]
@@ -63221,6 +64261,11 @@ export default {
           "reduce": [
             11
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            11
+          ]
         }
       },
       {
@@ -63240,6 +64285,11 @@ export default {
           ]
         },
         "*": {
+          "reduce": [
+            5
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             5
           ]
@@ -63270,6 +64320,11 @@ export default {
           "reduce": [
             11
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            11
+          ]
         }
       },
       {
@@ -63292,6 +64347,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -63314,6 +64374,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -63333,6 +64398,11 @@ export default {
           ]
         },
         "*": {
+          "reduce": [
+            10
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             10
           ]
@@ -63355,6 +64425,11 @@ export default {
           ]
         },
         "*": {
+          "reduce": [
+            9
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             9
           ]
@@ -66012,6 +67087,11 @@ export default {
           "reduce": [
             7
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            7
+          ]
         }
       },
       {
@@ -66026,6 +67106,11 @@ export default {
           ]
         },
         ")": {
+          "reduce": [
+            -1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             -1
           ]
@@ -66055,6 +67140,11 @@ export default {
           ]
         },
         ")": {
+          "reduce": [
+            7
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             7
           ]
@@ -66088,6 +67178,12 @@ export default {
             5,
             6
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5,
+            6
+          ]
         }
       },
       {
@@ -66102,6 +67198,11 @@ export default {
           ]
         },
         ")": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -66132,6 +67233,11 @@ export default {
           "reduce": [
             1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            1
+          ]
         }
       },
       {
@@ -66149,6 +67255,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -66163,6 +67274,11 @@ export default {
           ]
         },
         ")": {
+          "reduce": [
+            3
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             3
           ]
@@ -66180,6 +67296,11 @@ export default {
           ]
         },
         ")": {
+          "reduce": [
+            4
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             4
           ]
@@ -68524,6 +69645,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -68548,6 +69674,11 @@ export default {
           ]
         },
         "s": {
+          "reduce": [
+            -1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             -1
           ]
@@ -68594,6 +69725,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -68629,6 +69765,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -68658,6 +69799,11 @@ export default {
           ]
         },
         "s": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -68692,6 +69838,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -68723,6 +69874,11 @@ export default {
           "reduce": [
             7
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            7
+          ]
         }
       },
       {
@@ -68750,6 +69906,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -68777,6 +69938,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -68801,6 +69967,11 @@ export default {
           ]
         },
         "s": {
+          "reduce": [
+            6
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             6
           ]
@@ -70177,10 +71348,20 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
         "a": {
+          "reduce": [
+            -1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             -1
           ]
@@ -70196,10 +71377,20 @@ export default {
           "reduce": [
             1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            1
+          ]
         }
       },
       {
         "a": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -71410,6 +72601,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -71436,6 +72632,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -71453,6 +72654,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -71467,6 +72673,11 @@ export default {
           ]
         },
         "c": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -71484,6 +72695,11 @@ export default {
           ]
         },
         "c": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -71512,6 +72728,11 @@ export default {
           ]
         },
         "c": {
+          "reduce": [
+            3
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             3
           ]
@@ -73445,6 +74666,11 @@ export default {
           "reduce": [
             7
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            7
+          ]
         }
       },
       {
@@ -73459,6 +74685,11 @@ export default {
           ]
         },
         "c": {
+          "reduce": [
+            -1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             -1
           ]
@@ -73483,6 +74714,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -73501,6 +74737,11 @@ export default {
           ]
         },
         "c": {
+          "reduce": [
+            7
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             7
           ]
@@ -73525,6 +74766,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -73542,6 +74788,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -73556,6 +74807,11 @@ export default {
           ]
         },
         "c": {
+          "reduce": [
+            6
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             6
           ]
@@ -73584,6 +74840,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -73601,6 +74862,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -73615,6 +74881,11 @@ export default {
           ]
         },
         "c": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -75867,6 +77138,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -75886,6 +77162,11 @@ export default {
           ]
         },
         "c": {
+          "reduce": [
+            -1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             -1
           ]
@@ -75920,6 +77201,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -75939,6 +77225,11 @@ export default {
           ]
         },
         "c": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -75983,6 +77274,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -76002,6 +77298,11 @@ export default {
           ]
         },
         "c": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -76031,6 +77332,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -76053,6 +77359,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -76072,6 +77383,11 @@ export default {
           ]
         },
         "c": {
+          "reduce": [
+            5
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             5
           ]
@@ -78468,6 +79784,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -78491,6 +79812,11 @@ export default {
           ]
         },
         "rpar": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -78530,6 +79856,11 @@ export default {
           "reduce": [
             1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            1
+          ]
         }
       },
       {
@@ -78560,6 +79891,11 @@ export default {
           ]
         },
         "rpar": {
+          "reduce": [
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2
           ]
@@ -78599,6 +79935,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -78626,6 +79967,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -78645,6 +79991,11 @@ export default {
           ]
         },
         "rpar": {
+          "reduce": [
+            5
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             5
           ]
@@ -82453,6 +83804,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -82490,6 +83846,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -82524,6 +83885,11 @@ export default {
           ]
         },
         "pneumonic": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -82588,6 +83954,11 @@ export default {
           "reduce": [
             12
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            12
+          ]
         }
       },
       {
@@ -82625,6 +83996,11 @@ export default {
           "reduce": [
             10
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            10
+          ]
         }
       },
       {
@@ -82662,6 +84038,11 @@ export default {
           "reduce": [
             11
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            11
+          ]
         }
       },
       {
@@ -82696,6 +84077,11 @@ export default {
           ]
         },
         "pneumonic": {
+          "reduce": [
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2
           ]
@@ -82756,6 +84142,11 @@ export default {
           "reduce": [
             8
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            8
+          ]
         }
       },
       {
@@ -82793,6 +84184,11 @@ export default {
           "reduce": [
             9
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            9
+          ]
         }
       },
       {
@@ -82830,6 +84226,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -82864,6 +84265,11 @@ export default {
           ]
         },
         "pneumonic": {
+          "reduce": [
+            6
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             6
           ]
@@ -82924,6 +84330,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -82980,6 +84391,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -83014,6 +84430,11 @@ export default {
           ]
         },
         "pneumonic": {
+          "reduce": [
+            7
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             7
           ]
@@ -87067,6 +88488,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -87089,6 +88515,11 @@ export default {
           "reduce": [
             1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            1
+          ]
         }
       },
       {
@@ -87111,6 +88542,12 @@ export default {
           ]
         },
         "num": {
+          "reduce": [
+            2,
+            4
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2,
             4
@@ -87167,6 +88604,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -87189,6 +88631,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -87211,6 +88658,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -87230,6 +88682,11 @@ export default {
           ]
         },
         "num": {
+          "reduce": [
+            6
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             6
           ]
@@ -87252,6 +88709,11 @@ export default {
           ]
         },
         "num": {
+          "reduce": [
+            4
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             4
           ]
@@ -89591,6 +91053,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -89635,6 +91102,12 @@ export default {
           ]
         },
         "id": {
+          "reduce": [
+            3,
+            4
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             3,
             4
@@ -89700,6 +91173,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -89734,6 +91212,11 @@ export default {
           ]
         },
         "id": {
+          "reduce": [
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2
           ]
@@ -89774,6 +91257,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -89803,6 +91291,11 @@ export default {
           ]
         },
         "id": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -92316,6 +93809,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -92344,6 +93842,11 @@ export default {
           "reduce": [
             1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            1
+          ]
         }
       },
       {
@@ -92372,6 +93875,12 @@ export default {
           ]
         },
         ")": {
+          "reduce": [
+            2,
+            4
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2,
             4
@@ -92433,6 +93942,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -92465,6 +93979,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -92489,6 +94008,11 @@ export default {
           ]
         },
         ")": {
+          "reduce": [
+            4
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             4
           ]
@@ -92532,6 +94056,11 @@ export default {
           ]
         },
         ")": {
+          "reduce": [
+            5
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             5
           ]
@@ -95081,6 +96610,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -95131,6 +96665,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -95160,6 +96699,11 @@ export default {
           ]
         },
         "b": {
+          "reduce": [
+            4
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             4
           ]
@@ -95196,6 +96740,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -95223,6 +96772,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -95250,6 +96804,11 @@ export default {
           "reduce": [
             1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            1
+          ]
         }
       },
       {
@@ -95277,6 +96836,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -95301,6 +96865,11 @@ export default {
           ]
         },
         "b": {
+          "reduce": [
+            3
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             3
           ]
@@ -97060,6 +98629,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -97077,6 +98651,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -97091,6 +98670,11 @@ export default {
           ]
         },
         "c": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -97128,6 +98712,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -97142,6 +98731,11 @@ export default {
           ]
         },
         "c": {
+          "reduce": [
+            5
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             5
           ]
@@ -97167,6 +98761,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -97181,6 +98780,11 @@ export default {
           ]
         },
         "c": {
+          "reduce": [
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2
           ]
@@ -98864,6 +100468,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -98881,6 +100490,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -98895,6 +100509,11 @@ export default {
           ]
         },
         "b": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -98932,6 +100551,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -98949,6 +100573,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -98963,6 +100592,11 @@ export default {
           ]
         },
         "b": {
+          "reduce": [
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2
           ]
@@ -98980,6 +100614,11 @@ export default {
           ]
         },
         "b": {
+          "reduce": [
+            4
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             4
           ]
@@ -100818,6 +102457,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -100835,6 +102479,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -100849,6 +102498,11 @@ export default {
           ]
         },
         "*)": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -100891,6 +102545,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -100913,6 +102572,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -100930,6 +102594,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -100944,6 +102613,11 @@ export default {
           ]
         },
         "*)": {
+          "reduce": [
+            4
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             4
           ]
@@ -102645,6 +104319,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -102662,6 +104341,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -102676,6 +104360,11 @@ export default {
           ]
         },
         "d": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -102693,6 +104382,11 @@ export default {
           ]
         },
         "d": {
+          "reduce": [
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2
           ]
@@ -102710,6 +104404,11 @@ export default {
           ]
         },
         "d": {
+          "reduce": [
+            3
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             3
           ]
@@ -105536,6 +107235,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -105580,6 +107284,11 @@ export default {
           "reduce": [
             1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            1
+          ]
         }
       },
       {
@@ -105604,6 +107313,11 @@ export default {
           ]
         },
         "a": {
+          "reduce": [
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2
           ]
@@ -105651,6 +107365,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -105675,6 +107394,11 @@ export default {
           ]
         },
         "a": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -105726,6 +107450,11 @@ export default {
           "reduce": [
             10
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            10
+          ]
         }
       },
       {
@@ -105755,6 +107484,11 @@ export default {
           ]
         },
         "a": {
+          "reduce": [
+            3
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             3
           ]
@@ -105811,6 +107545,12 @@ export default {
             9,
             10
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            9,
+            10
+          ]
         }
       },
       {
@@ -105835,6 +107575,11 @@ export default {
           ]
         },
         "a": {
+          "reduce": [
+            8
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             8
           ]
@@ -105870,6 +107615,11 @@ export default {
           ]
         },
         "a": {
+          "reduce": [
+            6
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             6
           ]
@@ -105913,6 +107663,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -105940,6 +107695,11 @@ export default {
           "reduce": [
             9
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            9
+          ]
         }
       },
       {
@@ -105964,6 +107724,11 @@ export default {
           ]
         },
         "a": {
+          "reduce": [
+            7
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             7
           ]
@@ -109443,6 +111208,11 @@ export default {
           "reduce": [
             1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            1
+          ]
         }
       },
       {
@@ -109475,6 +111245,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -109499,6 +111274,11 @@ export default {
           ]
         },
         "id": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -109563,6 +111343,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -109605,6 +111390,12 @@ export default {
             8,
             9
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            8,
+            9
+          ]
         }
       },
       {
@@ -109632,6 +111423,11 @@ export default {
           "reduce": [
             10
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            10
+          ]
         }
       },
       {
@@ -109656,6 +111452,11 @@ export default {
           ]
         },
         "id": {
+          "reduce": [
+            3
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             3
           ]
@@ -109696,6 +111497,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -109723,6 +111529,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -109750,6 +111561,11 @@ export default {
           "reduce": [
             6
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            6
+          ]
         }
       },
       {
@@ -109774,6 +111590,11 @@ export default {
           ]
         },
         "id": {
+          "reduce": [
+            7
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             7
           ]
@@ -114280,6 +116101,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -114429,6 +116255,12 @@ export default {
             7,
             9
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            7,
+            9
+          ]
         }
       },
       {
@@ -114476,6 +116308,11 @@ export default {
           "reduce": [
             8
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            8
+          ]
         }
       },
       {
@@ -114523,6 +116360,11 @@ export default {
           "reduce": [
             10
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            10
+          ]
         }
       },
       {
@@ -114567,6 +116409,11 @@ export default {
           ]
         },
         "!": {
+          "reduce": [
+            11
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             11
           ]
@@ -114643,6 +116490,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -114690,6 +116542,11 @@ export default {
           "reduce": [
             1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            1
+          ]
         }
       },
       {
@@ -114737,6 +116594,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -114781,6 +116643,11 @@ export default {
           ]
         },
         "!": {
+          "reduce": [
+            4
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             4
           ]
@@ -114839,6 +116706,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -114886,6 +116758,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -114933,6 +116810,11 @@ export default {
           "reduce": [
             6
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            6
+          ]
         }
       },
       {
@@ -114977,6 +116859,11 @@ export default {
           ]
         },
         "!": {
+          "reduce": [
+            12
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             12
           ]
@@ -119321,6 +121208,11 @@ export default {
           "reduce": [
             8
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            8
+          ]
         }
       },
       {
@@ -119335,6 +121227,11 @@ export default {
           ]
         },
         "sq)": {
+          "reduce": [
+            -1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             -1
           ]
@@ -119368,6 +121265,11 @@ export default {
           "reduce": [
             8
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            8
+          ]
         }
       },
       {
@@ -119398,6 +121300,12 @@ export default {
             6,
             7
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            6,
+            7
+          ]
         }
       },
       {
@@ -119412,6 +121320,11 @@ export default {
           ]
         },
         "sq)": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -119445,6 +121358,11 @@ export default {
           "reduce": [
             8
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            8
+          ]
         }
       },
       {
@@ -119472,6 +121390,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -119489,6 +121412,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -119503,6 +121431,11 @@ export default {
           ]
         },
         "sq)": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -119520,6 +121453,11 @@ export default {
           ]
         },
         "sq)": {
+          "reduce": [
+            4
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             4
           ]
@@ -119537,6 +121475,11 @@ export default {
           ]
         },
         "sq)": {
+          "reduce": [
+            5
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             5
           ]
@@ -122767,6 +124710,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -122786,6 +124734,11 @@ export default {
           ]
         },
         "d": {
+          "reduce": [
+            -1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             -1
           ]
@@ -122841,6 +124794,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -122880,6 +124838,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -122902,6 +124865,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -122924,6 +124892,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -122943,6 +124916,11 @@ export default {
           ]
         },
         "d": {
+          "reduce": [
+            6
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             6
           ]
@@ -122965,6 +124943,11 @@ export default {
           ]
         },
         "d": {
+          "reduce": [
+            7
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             7
           ]
@@ -123013,6 +124996,11 @@ export default {
           "reduce": [
             1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            1
+          ]
         }
       },
       {
@@ -123046,6 +125034,11 @@ export default {
           "reduce": [
             8
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            8
+          ]
         }
       },
       {
@@ -123065,6 +125058,11 @@ export default {
           ]
         },
         "d": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -127349,6 +129347,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -127373,6 +129376,11 @@ export default {
           ]
         },
         "v": {
+          "reduce": [
+            -1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             -1
           ]
@@ -127409,6 +129417,11 @@ export default {
           "reduce": [
             1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            1
+          ]
         }
       },
       {
@@ -127438,6 +129451,11 @@ export default {
           ]
         },
         "v": {
+          "reduce": [
+            5
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             5
           ]
@@ -127473,6 +129491,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -127500,6 +129523,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -127524,6 +129552,11 @@ export default {
           ]
         },
         "v": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -129317,6 +131350,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -129348,6 +131386,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -129374,6 +131417,11 @@ export default {
           "reduce": [
             4
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            4
+          ]
         }
       },
       {
@@ -129396,6 +131444,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -129415,6 +131468,11 @@ export default {
           ]
         },
         "c": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -129456,6 +131514,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -129475,6 +131538,11 @@ export default {
           ]
         },
         "c": {
+          "reduce": [
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2
           ]
@@ -131415,6 +133483,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -131424,6 +133497,11 @@ export default {
           ]
         },
         "b": {
+          "reduce": [
+            -1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             -1
           ]
@@ -131447,6 +133525,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -131464,6 +133547,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -131473,6 +133561,11 @@ export default {
           ]
         },
         "b": {
+          "reduce": [
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2
           ]
@@ -131496,6 +133589,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -131505,6 +133603,11 @@ export default {
           ]
         },
         "b": {
+          "reduce": [
+            5
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             5
           ]
@@ -131517,6 +133620,11 @@ export default {
           ]
         },
         "b": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -131529,6 +133637,11 @@ export default {
           ]
         },
         "b": {
+          "reduce": [
+            4
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             4
           ]
@@ -134532,6 +136645,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -134565,6 +136683,11 @@ export default {
           "reduce": [
             1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            1
+          ]
         }
       },
       {
@@ -134597,6 +136720,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -134626,6 +136754,11 @@ export default {
           ]
         },
         "star": {
+          "reduce": [
+            4
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             4
           ]
@@ -134747,6 +136880,11 @@ export default {
           "reduce": [
             6
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            6
+          ]
         }
       },
       {
@@ -134777,6 +136915,11 @@ export default {
           ]
         },
         "star": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -134813,6 +136956,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -134842,6 +136990,11 @@ export default {
           ]
         },
         "star": {
+          "reduce": [
+            5
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             5
           ]
@@ -139666,10 +141819,20 @@ export default {
         },
         "B": {
           "shift": 3
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
         "a": {
+          "reduce": [
+            -1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             -1
           ]
@@ -139688,6 +141851,12 @@ export default {
             5,
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5,
+            3
+          ]
         }
       },
       {
@@ -139700,10 +141869,20 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
         "a": {
+          "reduce": [
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2
           ]
@@ -139722,6 +141901,12 @@ export default {
             5,
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5,
+            3
+          ]
         }
       },
       {
@@ -139729,10 +141914,20 @@ export default {
           "reduce": [
             1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            1
+          ]
         }
       },
       {
         "a": {
+          "reduce": [
+            4
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             4
           ]
@@ -142733,6 +144928,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -142796,6 +144996,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -142820,6 +145025,11 @@ export default {
           ]
         },
         "r": {
+          "reduce": [
+            6
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             6
           ]
@@ -142855,6 +145065,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -142879,6 +145094,11 @@ export default {
           ]
         },
         "r": {
+          "reduce": [
+            3
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             3
           ]
@@ -142932,6 +145152,11 @@ export default {
           "reduce": [
             1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            1
+          ]
         }
       },
       {
@@ -142972,6 +145197,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -142996,6 +145226,11 @@ export default {
           ]
         },
         "r": {
+          "reduce": [
+            4
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             4
           ]
@@ -148374,6 +150609,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -148403,6 +150643,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -148417,6 +150662,11 @@ export default {
           ]
         },
         "x": {
+          "reduce": [
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2
           ]
@@ -148436,6 +150686,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -148445,6 +150700,11 @@ export default {
           ]
         },
         "x": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -148457,6 +150717,11 @@ export default {
           ]
         },
         "x": {
+          "reduce": [
+            3
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             3
           ]
@@ -148477,6 +150742,11 @@ export default {
           ]
         },
         "x": {
+          "reduce": [
+            4
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             4
           ]
@@ -149777,6 +152047,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -149786,6 +152061,11 @@ export default {
           ]
         },
         "c": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -149798,6 +152078,11 @@ export default {
           ]
         },
         "c": {
+          "reduce": [
+            0
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0
           ]
@@ -153584,6 +155869,11 @@ export default {
           "reduce": [
             -1
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            -1
+          ]
         }
       },
       {
@@ -153628,6 +155918,11 @@ export default {
           ]
         },
         "rpar": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -153682,6 +155977,11 @@ export default {
           "reduce": [
             2
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            2
+          ]
         }
       },
       {
@@ -153729,6 +156029,11 @@ export default {
           ]
         },
         "rpar": {
+          "reduce": [
+            6
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             6
           ]
@@ -153787,6 +156092,11 @@ export default {
           ]
         },
         "rpar": {
+          "reduce": [
+            3
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             3
           ]
@@ -153865,6 +156175,11 @@ export default {
           "reduce": [
             0
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            0
+          ]
         }
       },
       {
@@ -153934,6 +156249,11 @@ export default {
           "reduce": [
             5
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            5
+          ]
         }
       },
       {
@@ -153992,6 +156312,11 @@ export default {
           "reduce": [
             9
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            9
+          ]
         }
       },
       {
@@ -154036,6 +156361,11 @@ export default {
           ]
         },
         "rpar": {
+          "reduce": [
+            10
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             10
           ]
@@ -154108,6 +156438,11 @@ export default {
           "reduce": [
             8
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            8
+          ]
         }
       },
       {
@@ -154152,6 +156487,11 @@ export default {
           ]
         },
         "rpar": {
+          "reduce": [
+            4
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             4
           ]
@@ -154207,6 +156547,11 @@ export default {
           ]
         },
         "rpar": {
+          "reduce": [
+            7
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             7
           ]
@@ -160652,6 +162997,11 @@ export default {
           "reduce": [
             8
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            8
+          ]
         }
       },
       {
@@ -160661,6 +163011,11 @@ export default {
           ]
         },
         "*": {
+          "reduce": [
+            -1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             -1
           ]
@@ -160674,6 +163029,12 @@ export default {
           ]
         },
         "*": {
+          "reduce": [
+            0,
+            6
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             0,
             6
@@ -160698,6 +163059,11 @@ export default {
           "reduce": [
             3
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            3
+          ]
         }
       },
       {
@@ -160707,6 +163073,11 @@ export default {
           ]
         },
         "*": {
+          "reduce": [
+            4
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             4
           ]
@@ -160719,6 +163090,11 @@ export default {
           ]
         },
         "*": {
+          "reduce": [
+            7
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             7
           ]
@@ -160731,6 +163107,11 @@ export default {
           ]
         },
         "*": {
+          "reduce": [
+            5
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             5
           ]
@@ -160752,6 +163133,11 @@ export default {
           "reduce": [
             8
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            8
+          ]
         }
       },
       {
@@ -160770,6 +163156,11 @@ export default {
           "reduce": [
             8
           ]
+        },
+        "Grammar.END": {
+          "reduce": [
+            8
+          ]
         }
       },
       {
@@ -160779,6 +163170,11 @@ export default {
           ]
         },
         "*": {
+          "reduce": [
+            1
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             1
           ]
@@ -160791,6 +163187,11 @@ export default {
           ]
         },
         "*": {
+          "reduce": [
+            2
+          ]
+        },
+        "Grammar.END": {
           "reduce": [
             2
           ]

--- a/test/grammar/calculations/parsing/lr/lr0_table.test.js
+++ b/test/grammar/calculations/parsing/lr/lr0_table.test.js
@@ -1,4 +1,5 @@
 import Grammar from "../../../../../src/grammar/index.js";
+import { END } from "../../../../../src/grammar/symbols.js";
 import assert from "node:assert/strict";
 
 describe("lr0Table", function() {
@@ -19,10 +20,16 @@ describe("lr0Table", function() {
       {
         "a": {
           "reduce": [-1]
+        },
+        [END]: {
+          "reduce": [-1]
         }
       },
       {
         "a": {
+          "reduce": [0]
+        },
+        [END]: {
           "reduce": [0]
         }
       }


### PR DESCRIPTION
This addresses #41.

When implementing this originally, I omitted the end of input symbol from LR(0) parse tables. This is possibly because Louden 1997 doesn't include such a column in one of its examples.

However, since grammar classification uses the parsing tables, it wasn't able to detect that this grammar had a reduce/reduce conflict:

```
S -> E.
E -> E.
```

Of course, this grammar is cyclic and has no terminal symbols, so if classification doesn't check for reduce-reduce conflicts using a table that omits the end of input symbol, it will think there are no conflicts (since they were dropped when creating the table from the automaton).

LL(1) classification has a similar problem, which I'll address in another PR.