### PR TITLE
Improve parsing and display of escapes and nonprinting characters

### DIFF
--- a/src/components/helpers.js
+++ b/src/components/helpers.js
@@ -1,9 +1,40 @@
 import { END } from "../grammar/symbols.js";
 import { createElement as h, Fragment } from "react";
 
-const ARROW = "\u2192";
-const EPSILON = "\u03B5";
-const BLANK = "\u2B1A";
+const ARROW = "→";
+
+const EPSILON = "ε";
+
+const NONPRINTING_PATTERN = /(\s|\x08|\0)/; // eslint-disable-line no-control-regex
+
+const NONPRINTING = {
+  "\0": "\\0",
+  "\n": "\\n",
+  "\r": "\\r",
+  "\v": "\\v",
+  "\t": "\\t",
+  "\b": "\\b",
+  "\f": "\\f"
+};
+
+const BARE_NONPRINTING = {
+  "\0": "\\\\0",
+  "\n": "\\\\n",
+  "\r": "\\\\r",
+  "\v": "\\\\v",
+  "\t": "\\\\t",
+  "\b": "\\\\b",
+  "\f": "\\\\f"
+};
+
+const SPACE = "␣";
+
+const ESCAPE = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  "\"": "&quot;"
+};
 
 export function fillArray(count, fn) {
   let array = [];
@@ -44,7 +75,13 @@ export function formatSymbolList(symbols, info, separator) {
 }
 
 function prettifySymbol(symbol) {
-  return symbol.replace(/\s/g, BLANK);
+  return symbol.split(NONPRINTING_PATTERN).map((str, index) => {
+    if (index % 2 == 1) {
+      return h("span", { className: "np" }, NONPRINTING[str] || SPACE);
+    } else {
+      return str;
+    }
+  });
 }
 
 export function formatSymbol(symbol, info) {
@@ -85,13 +122,6 @@ export function formatSentence(sentence, info) {
   return formatSymbolList(sentence, info, " ");
 }
 
-const ESCAPE = {
-  "&": "&amp;",
-  "<": "&lt;",
-  ">": "&gt;",
-  "\"": "&quot;"
-};
-
 export function escapeString(string) {
   return string.replace(/[&<>"]/g, function(name) {
     return ESCAPE[name];
@@ -99,7 +129,13 @@ export function escapeString(string) {
 }
 
 function barePrettifySymbol(symbol) {
-  return symbol.replace(/'/g, "&prime;").replace(/\s/g, BLANK);
+  return symbol.split(NONPRINTING_PATTERN).map((str, index) => {
+    if (index % 2 == 1) {
+      return BARE_NONPRINTING[str] || SPACE;
+    } else {
+      return str;
+    }
+  }).join("");
 }
 
 export function bareFormatSymbol(symbol, info) {

--- a/src/parser/index.js
+++ b/src/parser/index.js
@@ -1,5 +1,25 @@
 import { parser } from "./rules.js";
 
+const ESCAPES = {
+  "0": "\0",
+  "n": "\n",
+  "r": "\r",
+  "v": "\v",
+  "t": "\t",
+  "b": "\b",
+  "f": "\f",
+  "\n": "",
+  "\r": ""
+};
+
+function interpretEscapes(str) {
+  return str.replaceAll(/\\(?:x([0-9a-fA-F]{2})|u(?:\{([0-9a-fA-F]+)\}|([0-9a-fA-F]{4})))/g, function(_, hex, u1, u2) {
+    return String.fromCodePoint(parseInt(hex || u1 || u2, 16));
+  }).replaceAll(/\\(.)/gs, function(_, char) {
+    return ESCAPES[char] || char;
+  });
+}
+
 export default function(src) {
   let tree = parser.parse(src);
   let cursor = tree.cursor();
@@ -27,7 +47,7 @@ export default function(src) {
         production.push(symbol);
       }
     } else if (cursor.name === "QuotedSymbol") {
-      let symbol = src.slice(cursor.from + 1, cursor.to - 1);
+      let symbol = interpretEscapes(src.slice(cursor.from + 1, cursor.to - 1));
 
       if (typeof production === "undefined") {
         head = symbol;

--- a/styles/analysis/symbols.css
+++ b/styles/analysis/symbols.css
@@ -5,9 +5,14 @@
 
 .symbols u {
   text-decoration: none;
-  background: #ddd;
+  background: #eee;
 }
 
 .symbols b {
   font: bold 10pt courier;
+}
+
+.symbols .np {
+  background: #eee;
+  color: #999;
 }

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -24,8 +24,11 @@ describe("helpers", function() {
 
       let output = formatSymbol(" ", info);
 
-      assert.deepStrictEqual(output.type, "b");
-      assert.deepStrictEqual(output.props, { children: "\u2B1A" });
+      assert.strictEqual(output.type, "b");
+      assert.strictEqual(output.props.children[0], "");
+      assert.strictEqual(output.props.children[1].type, "span");
+      assert.strictEqual(output.props.children[1].props.className, "np");
+      assert.strictEqual(output.props.children[1].props.children[0], "␣");
     });
 
     it("refuses to format an unknown symbol", function() {
@@ -58,7 +61,16 @@ describe("helpers", function() {
         nonterminals: new Set()
       };
 
-      assert.deepStrictEqual(bareFormatSymbol(" ", info), "\u2B1A");
+      assert.deepStrictEqual(bareFormatSymbol(" ", info), "␣");
+    });
+
+    it("double escapes other nonprinting characters", function() {
+      let info = {
+        terminals: new Set(["\n"]),
+        nonterminals: new Set()
+      };
+
+      assert.deepStrictEqual(bareFormatSymbol("\n", info), "\\\\n");
     });
 
     it("refuses to format an unknown symbol", function() {

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -32,33 +32,38 @@ describe("parser", function() {
   });
 
   it("symbols can be quoted", function() {
-    assert.deepStrictEqual(parser("\"A\" -> \"a\"."), { productions: [["A", "a"]] });
-    assert.deepStrictEqual(parser("\"->\" -> ."), { productions: [["->"]] });
+    assert.deepStrictEqual(parser(`"A" -> "a".`), { productions: [["A", "a"]] });
+    assert.deepStrictEqual(parser(`"->" -> .`), { productions: [["->"]] });
   });
 
   it("quoted symbols can contain escapes", function() {
-    assert.deepStrictEqual(parser("\"\\\"\" -> ."), { productions: [["\\\""]] });
-    assert.deepStrictEqual(parser("\"\\\\\" -> ."), { productions: [["\\\\"]] });
-    assert.deepStrictEqual(parser("\"'\" -> ."), { productions: [["'"]] });
-    assert.deepStrictEqual(parser("'\\'' -> ."), { productions: [["\\'"]] });
-    assert.deepStrictEqual(parser("'\"' -> ."), { productions: [["\""]] });
+    assert.deepStrictEqual(parser(`"\\"" -> .`), { productions: [[`\\"`]] });
+    assert.deepStrictEqual(parser(`"\\'" -> .`), { productions: [[`\\'`]] });
+    assert.deepStrictEqual(parser(`'\\'' -> .`), { productions: [[`\\'`]] });
+    assert.deepStrictEqual(parser(`'\\"' -> .`), { productions: [[`\\"`]] });
+    assert.deepStrictEqual(parser(`"\\\\" -> .`), { productions: [[`\\\\`]] });
 
-    assert.deepStrictEqual(parser("\"\\b\" -> ."), { productions: [["\\b"]] });
-    assert.deepStrictEqual(parser("\"\\f\" -> ."), { productions: [["\\f"]] });
-    assert.deepStrictEqual(parser("\"\\n\" -> ."), { productions: [["\\n"]] });
-    assert.deepStrictEqual(parser("\"\\r\" -> ."), { productions: [["\\r"]] });
-    assert.deepStrictEqual(parser("\"\\t\" -> ."), { productions: [["\\t"]] });
-    assert.deepStrictEqual(parser("\"\\v\" -> ."), { productions: [["\\v"]] });
-    assert.deepStrictEqual(parser("\"\\0\" -> ."), { productions: [["\\0"]] });
+    assert.deepStrictEqual(parser(`"\\b" -> .`), { productions: [[`\\b`]] });
+    assert.deepStrictEqual(parser(`"\\f" -> .`), { productions: [[`\\f`]] });
+    assert.deepStrictEqual(parser(`"\\n" -> .`), { productions: [[`\\n`]] });
+    assert.deepStrictEqual(parser(`"\\r" -> .`), { productions: [[`\\r`]] });
+    assert.deepStrictEqual(parser(`"\\t" -> .`), { productions: [[`\\t`]] });
+    assert.deepStrictEqual(parser(`"\\v" -> .`), { productions: [[`\\v`]] });
+    assert.deepStrictEqual(parser(`"\\0" -> .`), { productions: [[`\\0`]] });
 
-    assert.deepStrictEqual(parser("\"\\xA9\" -> ."), { productions: [["\\xA9"]] });
-    assert.deepStrictEqual(parser("\"\\xa9\" -> ."), { productions: [["\\xa9"]] });
+    assert.deepStrictEqual(parser(`"\\\n" -> .`), { productions: [[`\\\n`]] });
 
-    assert.deepStrictEqual(parser("\"\\u00A9\" -> ."), { productions: [["\\u00A9"]] });
-    assert.deepStrictEqual(parser("\"\\u00a9\" -> ."), { productions: [["\\u00a9"]] });
-    assert.deepStrictEqual(parser("\"\\u2665\" -> ."), { productions: [["\\u2665"]] });
+    // COPYRIGHT SIGN
+    assert.deepStrictEqual(parser(`"\\xA9" -> .`), { productions: [[`\\xA9`]] });
+    assert.deepStrictEqual(parser(`"\\xa9" -> .`), { productions: [[`\\xa9`]] });
+    assert.deepStrictEqual(parser(`"\\u00A9" -> .`), { productions: [[`\\u00A9`]] });
+    assert.deepStrictEqual(parser(`"\\u00a9" -> .`), { productions: [[`\\u00a9`]] });
 
-    assert.deepStrictEqual(parser("\"\\u{1D306}\" -> ."), { productions: [["\\u{1D306}"]] });
+    // BLACK HEART SUIT
+    assert.deepStrictEqual(parser(`"\\u2665" -> .`), { productions: [["\\u2665"]] });
+
+    // TETRAGRAM FOR CENTRE
+    assert.deepStrictEqual(parser(`"\\u{1D306}" -> .`), { productions: [["\\u{1D306}"]] });
   });
 
   it("nonterminals don't need to be capitalized", function() {
@@ -108,7 +113,7 @@ describe("parser", function() {
       assert.deepStrictEqual(parser("A -> 1 ."), { error: new Error("Parse error") });
     });
 
-    it("quoted symbols can't contain a newline", function() {
+    it("quoted symbols can't contain an unescaped newline", function() {
       assert.deepStrictEqual(parser("\"A\n\" -> a ."), { error: new Error("Parse error") });
     });
   });

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -37,33 +37,56 @@ describe("parser", function() {
   });
 
   it("quoted symbols can contain escapes", function() {
-    assert.deepStrictEqual(parser(`"\\"" -> .`), { productions: [[`\\"`]] });
-    assert.deepStrictEqual(parser(`"\\'" -> .`), { productions: [[`\\'`]] });
-    assert.deepStrictEqual(parser(`'\\'' -> .`), { productions: [[`\\'`]] });
-    assert.deepStrictEqual(parser(`'\\"' -> .`), { productions: [[`\\"`]] });
-    assert.deepStrictEqual(parser(`"\\\\" -> .`), { productions: [[`\\\\`]] });
+    // QUOTATION MARK and APOSTROPHE
+    assert.deepStrictEqual(parser(`"\\"" -> .`), { productions: [[`"`]] });
+    assert.deepStrictEqual(parser(`"\\'" -> .`), { productions: [[`'`]] });
+    assert.deepStrictEqual(parser(`'\\'' -> .`), { productions: [[`'`]] });
+    assert.deepStrictEqual(parser(`'\\"' -> .`), { productions: [[`"`]] });
+    assert.deepStrictEqual(parser(`"\\\\" -> .`), { productions: [[`\\`]] });
 
-    assert.deepStrictEqual(parser(`"\\b" -> .`), { productions: [[`\\b`]] });
-    assert.deepStrictEqual(parser(`"\\f" -> .`), { productions: [[`\\f`]] });
-    assert.deepStrictEqual(parser(`"\\n" -> .`), { productions: [[`\\n`]] });
-    assert.deepStrictEqual(parser(`"\\r" -> .`), { productions: [[`\\r`]] });
-    assert.deepStrictEqual(parser(`"\\t" -> .`), { productions: [[`\\t`]] });
-    assert.deepStrictEqual(parser(`"\\v" -> .`), { productions: [[`\\v`]] });
-    assert.deepStrictEqual(parser(`"\\0" -> .`), { productions: [[`\\0`]] });
+    // C-style escapes
+    assert.deepStrictEqual(parser(`"\\b" -> .`), { productions: [[`\b`]] });
+    assert.deepStrictEqual(parser(`"\\f" -> .`), { productions: [[`\f`]] });
+    assert.deepStrictEqual(parser(`"\\n" -> .`), { productions: [[`\n`]] });
+    assert.deepStrictEqual(parser(`"\\r" -> .`), { productions: [[`\r`]] });
+    assert.deepStrictEqual(parser(`"\\t" -> .`), { productions: [[`\t`]] });
+    assert.deepStrictEqual(parser(`"\\v" -> .`), { productions: [[`\v`]] });
+    assert.deepStrictEqual(parser(`"\\0" -> .`), { productions: [[`\0`]] });
 
-    assert.deepStrictEqual(parser(`"\\\n" -> .`), { productions: [[`\\\n`]] });
+    // Identity escapes
+    assert.deepStrictEqual(parser(`"\\z" -> .`), { productions: [[`z`]] });
+
+    // Escaped line terminator
+    assert.deepStrictEqual(parser(`"\\\n" -> .`), { productions: [[`\n`]] });
+    assert.deepStrictEqual(parser(`"\\\r" -> .`), { productions: [[`\r`]] });
 
     // COPYRIGHT SIGN
-    assert.deepStrictEqual(parser(`"\\xA9" -> .`), { productions: [[`\\xA9`]] });
-    assert.deepStrictEqual(parser(`"\\xa9" -> .`), { productions: [[`\\xa9`]] });
-    assert.deepStrictEqual(parser(`"\\u00A9" -> .`), { productions: [[`\\u00A9`]] });
-    assert.deepStrictEqual(parser(`"\\u00a9" -> .`), { productions: [[`\\u00a9`]] });
+    assert.deepStrictEqual(parser(`"\\xA9" -> .`), { productions: [[`\xA9`]] });
+    assert.deepStrictEqual(parser(`"\\xa9" -> .`), { productions: [[`\xa9`]] });
+    assert.deepStrictEqual(parser(`"\\u00A9" -> .`), { productions: [[`\u00A9`]] });
+    assert.deepStrictEqual(parser(`"\\u00a9" -> .`), { productions: [[`\u00a9`]] });
+    assert.deepStrictEqual(parser(`"\\u00a9" -> .`), { productions: [[`\u{00A9}`]] });
+    assert.deepStrictEqual(parser(`"\\u00a9" -> .`), { productions: [[`\u{00a9}`]] });
 
     // BLACK HEART SUIT
-    assert.deepStrictEqual(parser(`"\\u2665" -> .`), { productions: [["\\u2665"]] });
+    assert.deepStrictEqual(parser(`"\\u2665" -> .`), { productions: [[`\u2665`]] });
+    assert.deepStrictEqual(parser(`"\\u{2665}" -> .`), { productions: [[`\u{2665}`]] });
 
     // TETRAGRAM FOR CENTRE
-    assert.deepStrictEqual(parser(`"\\u{1D306}" -> .`), { productions: [["\\u{1D306}"]] });
+    assert.deepStrictEqual(parser(`"\\u{1D306}" -> .`), { productions: [[`\u{1D306}`]] });
+
+    // AMPERSAND (\x and two hex digits)
+    assert.deepStrictEqual(parser(`"\\x2665" -> .`), { productions: [[`\x2665`]] });
+
+    // MODIFIER LETTER CAPITAL D (\u without braces)
+    assert.deepStrictEqual(parser(`"\\u1D306" -> .`), { productions: [[`\u1D306`]] });
+  });
+
+  it("quoted symbols can contain multiple escapes", function() {
+    assert.deepStrictEqual(
+      parser(`"\\" \\0 \\xA9 \\u00A9 \\u{2665}" -> .`),
+      { productions: [[`" \0 \xA9 \u00A9 \u{2665}`]] }
+    );
   });
 
   it("nonterminals don't need to be capitalized", function() {


### PR DESCRIPTION
Addresses #46 and #47.

- Escapes in symbols are interpreted when parsing. For example, `"\\"` will be interpreted as a single backslash.
- Nonprinting characters such as spaces and control characters are displayed with a different style.
- The space placeholder is now ␣ "OPEN BOX".
- Nonprinting characters that are usually escaped with a C-style escape are displayed in that form. For example, `\n`.