### PR TITLE
Escape backslashes for Graphviz

### DIFF
--- a/src/components/helpers.js
+++ b/src/components/helpers.js
@@ -123,9 +123,9 @@ export function formatSentence(sentence, info) {
 }
 
 export function escapeString(string) {
-  return string.replace(/[&<>"]/g, function(name) {
+  return string.replaceAll(/[&<>"]/g, function(name) {
     return ESCAPE[name];
-  });
+  }).replaceAll("\\", "\\\\");
 }
 
 function barePrettifySymbol(symbol) {

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -66,11 +66,12 @@ describe("helpers", function() {
 
     it("double escapes other nonprinting characters", function() {
       let info = {
-        terminals: new Set(["\n"]),
+        terminals: new Set(["\n", "\\"]),
         nonterminals: new Set()
       };
 
       assert.deepStrictEqual(bareFormatSymbol("\n", info), "\\\\n");
+      assert.deepStrictEqual(bareFormatSymbol("\\", info), "\\\\");
     });
 
     it("refuses to format an unknown symbol", function() {


### PR DESCRIPTION
A symbol that was just `"\\"` (backslash) wouldn't show up in automata diagrams.