### PR TITLE
Don't use structuredClone to copy LR(1) automata

### DIFF
--- a/src/grammar/calculations/parsing/lr/lalr1_automaton.js
+++ b/src/grammar/calculations/parsing/lr/lalr1_automaton.js
@@ -1,13 +1,23 @@
 import { collapseLookaheads, mergeItems } from "./helpers.js";
 import * as build from "./build/lr0.js";
 
+function copyLR1Automaton(automaton) {
+  return automaton.map(state => {
+    return {
+      kernel: state.kernel.map(item => Object.assign({}, item)),
+      items: state.items.map(item => Object.assign({}, item)),
+      transitions: Object.assign({}, state.transitions)
+    };
+  });
+}
+
 export default function({ lr1Automaton }) {
 
   var i, j;
 
   // Copy the LR(1) automaton.
 
-  const automaton = structuredClone(lr1Automaton);
+  const automaton = copyLR1Automaton(lr1Automaton);
 
   // Collapse lookaheads.
 

--- a/test/manual/performance.js
+++ b/test/manual/performance.js
@@ -1,0 +1,54 @@
+import Grammar from "../../src/grammar/index.js";
+
+function measure(operation, timeLimit) {
+  let callCount = 0;
+
+  const startTime = performance.now();
+
+  while (performance.now() - startTime < timeLimit) {
+    operation();
+    callCount++;
+  }
+
+  const stopTime = performance.now();
+  const duration = (stopTime - startTime) / 1000;
+  const speed = callCount / duration;
+
+  return `${callCount} in ${duration.toFixed(2)} s, ${speed.toFixed(2)} calls/s`
+}
+
+function randomProductions({ productionCount, maximumProductionLength, symbolCount }) {
+  const productions = [];
+
+  for (let i = 0; i < productionCount; i++) {
+    const productionLength = 1 + Math.floor(Math.random() * maximumProductionLength);
+    const production = [];
+
+    for (let j = 0; j < productionLength; j++) {
+      production.push(`s${Math.floor(Math.random() * symbolCount)}`);
+    }
+
+    productions.push(production);
+  }
+
+  return productions;
+}
+
+const tests = [
+  { productionCount: 10, maximumProductionLength: 10, symbolCount: 20 },
+  { productionCount: 20, maximumProductionLength: 10, symbolCount: 20 },
+  { productionCount: 50, maximumProductionLength: 10, symbolCount: 20 },
+  { productionCount: 100, maximumProductionLength: 10, symbolCount: 20 },
+  { productionCount: 200, maximumProductionLength: 10, symbolCount: 20 },
+  { productionCount: 500, maximumProductionLength: 10, symbolCount: 20 }
+];
+
+const timeLimit = 5000;
+
+for (const params of tests) {
+  const result = measure(() => {
+    const productions = randomProductions(params);
+    new Grammar(productions).calculations.classification
+  }, timeLimit);
+  console.log(`productionCount=${params.productionCount}: ${result}`);
+}


### PR DESCRIPTION
Also add a very basic manual performance test that uses randomly-generated grammars.

Replacing structuredClone appears to improve the performance of the LALR(1) automaton calculation a little bit. However, the apparent performance improvement on smaller grammars is misleading because structuredClone should only be called once per analysis.

See #55.